### PR TITLE
Booking delete behaviour

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -56,7 +56,7 @@ class BookingsController < ApplicationController
     @car = @booking.car
     authorize @booking
     @booking.destroy
-    redirect_to car_path(@car)
+    redirect_back(fallback_location: 'something')
     flash.notice = "You have cancelled your booking"
   end
 

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -27,13 +27,14 @@ class BookingsController < ApplicationController
       end
     end
     if available.count > 0
-      @car = Car.find(params[:car_id])
+      #@car = Car.find(params[:car_id])
       @booking = Booking.new
       authorize @booking
+      redirect_back(fallback_location: 'something')
       flash.alert = "Dates not available"
-      @booking.start_date = @booking.start_date
-      @booking.end_date = @booking.end_date
-      render :new, status: :unprocessable_entity
+      #@booking.start_date = @booking.start_date
+      #@booking.end_date = @booking.end_date
+      #render :new, status: :unprocessable_entity
     else
       @car = Car.find(params[:car_id])
       @booking = Booking.new(booking_params)
@@ -44,9 +45,10 @@ class BookingsController < ApplicationController
         redirect_to car_path(@car.id)
         flash.notice = "You have booked this car from the #{@booking.start_date} to the #{@booking.end_date}"
       else
-        @booking.start_date = @booking.start_date
-        @booking.end_date = @booking.end_date
-        render :new
+        #@booking.start_date = @booking.start_date
+        #@booking.end_date = @booking.end_date
+        flash.alert = "Booking not validated"
+        #render :new
       end
     end
   end


### PR DESCRIPTION
Now that the booking form is on the car show page, I've had to redo the double booking alerts system and the behaviour when you delete a booking.
- booking delete: you stay on the same page (dashboard page or show page)
- double booking: you stay on the same page and you get an alert